### PR TITLE
Move mocha to devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,9 @@
   "license": "MIT",
   "dependencies": {
     "marked": "^0.3.6",
-    "marked-terminal": "^1.6.2",
-    "mocha": "^3.0.2"
+    "marked-terminal": "^1.6.2"
   },
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "^3.0.2"
   }
 }


### PR DESCRIPTION
Hey,

we noticed that this module also pulls in mocha, which should be only a dev dependency. Can you merge this and publish a patch release? Thank you!
