### PR TITLE
remove `mocha` from `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "marked": "^0.3.6",
-    "marked-terminal": "^1.6.2",
-    "mocha": "^3.0.2"
+    "marked-terminal": "^1.6.2"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
it's in both `devDependencies` and `dependencies` right now and i believe it should only be in `devDependencies`
