### PR TITLE
Bump back marked-terminal and bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-usage",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Easily show CLI usage from a markdown source file",
   "main": "index.js",
   "scripts": {
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "marked": "^0.3.6",
-    "marked-terminal": "^1.6.2"
+    "marked-terminal": "1.6.1"
   },
   "devDependencies": {
     "mocha": "^3.0.2"


### PR DESCRIPTION
1.6.2 isn't a real release of marked-terminal and is causing this installation to fail.
